### PR TITLE
Add support for separate read and write or multi-colored LEDs

### DIFF
--- a/AdamNet_Drive_Emulator/ProcessKeys.ino
+++ b/AdamNet_Drive_Emulator/ProcessKeys.ino
@@ -292,9 +292,9 @@ void ProcessKeys(){                                                // Process a 
         LCDTopDelay = 1;
         for (int blinks = 1; blinks <= NumberofBlinks; blinks++){
           delay(200);
-          digitalWrite(StatusLed[0], !digitalRead(StatusLed[0]));
+          digitalWrite(ActivityLed, !digitalRead(ActivityLed));
           delay(200);
-          digitalWrite(StatusLed[0], !digitalRead(StatusLed[0]));
+          digitalWrite(ActivityLed, !digitalRead(ActivityLed));
         }
       }
     }

--- a/Change Log.txt
+++ b/Change Log.txt
@@ -1,3 +1,5 @@
+Version 0.92
+- Added support for separate read and write LEDs or multi-colored LEDs.
 Version 0.91
 - Fix a bug in the boot disk handling on reset.
 - Renamed the LCD text "Boot Disk On" to "AutoMnt Boot On" and "Boot Disk Off" to "AutoMnt Boot Off". This matches what the ADE is actually doing when the Drive Select key is held for a long key press. It doesn't unmount the boot.dsk, it enables and disables the auto mount on a reset.


### PR DESCRIPTION
I made the following enhancement that separates out the read and write operations as separate pins. This allows you to:
- Have a different LED for read and write operations per drive
- Use a multi-colored LED to indicate the difference between a read and write operation

In my case I used a multi-colored LED where green was used for read operations and red was used for write operations (see photos included below for an example). 

I configured the software to operate exactly like previous versions by default (i.e. pin 13 is used for all drives, both read and write), but users can modify the pins declared on lines 23 and 24 to do whatever they like.

Feel free to delete this Pull Request if you are not interested in this change.

**Drive 2 Reading**
![image](https://user-images.githubusercontent.com/5286686/111558084-0ecd2b00-875c-11eb-9309-690fc48825f3.png)

**Drive 2 Writing**
![image](https://user-images.githubusercontent.com/5286686/111558123-286e7280-875c-11eb-96b0-5d39c88d7ebd.png)
